### PR TITLE
Integrate dylan-tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.hdp
 _build
+_packages/
+registry/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "ext/meta"]
-	path = ext/meta
-	url = https://github.com/dylan-lang/meta.git

--- a/registry/generic/meta
+++ b/registry/generic/meta
@@ -1,1 +1,0 @@
-abstract://dylan/ext/meta/meta.lid

--- a/registry/generic/xml-parser
+++ b/registry/generic/xml-parser
@@ -1,1 +1,0 @@
-abstract://dylan/xml-parser.lid

--- a/registry/generic/xml-test-suite
+++ b/registry/generic/xml-test-suite
@@ -1,1 +1,0 @@
-abstract://dylan/tests/xml-test-suite.lid


### PR DESCRIPTION
- Eliminate the use of submodules.

  Git submodules were causing issues with GH actions unable to download the 'xml-parser' library as a dependency of the 'http' library. This problem is resolved by integrating dylan-tool, rendering submodules unnecessary.

- Update .gitignore to exclude dylan-tool cache and registry directories.

- Remove the generic registry as dylan-tool will generate another registry.